### PR TITLE
DBOS Client should not run migrations

### DIFF
--- a/dbos/_app_db.py
+++ b/dbos/_app_db.py
@@ -36,11 +36,12 @@ class ApplicationDatabase:
         database_url: str,
         engine_kwargs: Dict[str, Any],
         debug_mode: bool = False,
+        client_mode: bool = False,
     ):
         app_db_url = sa.make_url(database_url).set(drivername="postgresql+psycopg")
 
         # If the application database does not already exist, create it
-        if not debug_mode:
+        if not debug_mode and not client_mode:
             postgres_db_engine = sa.create_engine(
                 app_db_url.set(database="postgres"),
                 **engine_kwargs,
@@ -65,7 +66,7 @@ class ApplicationDatabase:
         self.debug_mode = debug_mode
 
         # Create the dbos schema and transaction_outputs table in the application database
-        if not debug_mode:
+        if not debug_mode and not client_mode:
             with self.engine.begin() as conn:
                 schema_creation_query = sa.text(
                     f"CREATE SCHEMA IF NOT EXISTS {ApplicationSchema.schema}"

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -107,6 +107,7 @@ class DBOSClient:
                 "pool_size": 2,
             },
             sys_db_name=system_database,
+            client_mode=True,
         )
         self._app_db = ApplicationDatabase(
             database_url=database_url,
@@ -115,6 +116,7 @@ class DBOSClient:
                 "max_overflow": 0,
                 "pool_size": 2,
             },
+            client_mode=True,
         )
         self._db_url = database_url
 

--- a/dbos/_client.py
+++ b/dbos/_client.py
@@ -99,6 +99,7 @@ class WorkflowHandleClientAsyncPolling(Generic[R]):
 
 class DBOSClient:
     def __init__(self, database_url: str, *, system_database: Optional[str] = None):
+        # We only create database connections but do not run migrations
         self._sys_db = SystemDatabase(
             database_url=database_url,
             engine_kwargs={
@@ -107,7 +108,6 @@ class DBOSClient:
                 "pool_size": 2,
             },
             sys_db_name=system_database,
-            client_mode=True,
         )
         self._app_db = ApplicationDatabase(
             database_url=database_url,
@@ -116,7 +116,6 @@ class DBOSClient:
                 "max_overflow": 0,
                 "pool_size": 2,
             },
-            client_mode=True,
         )
         self._db_url = database_url
 

--- a/dbos/_dbos.py
+++ b/dbos/_dbos.py
@@ -433,6 +433,10 @@ class DBOS:
             if debug_mode:
                 return
 
+            # Run migrations for the system and application databases
+            self._sys_db.run_migrations()
+            self._app_db.run_migrations()
+
             admin_port = self._config.get("runtimeConfig", {}).get("admin_port")
             if admin_port is None:
                 admin_port = 3001

--- a/dbos/_sys_db.py
+++ b/dbos/_sys_db.py
@@ -231,6 +231,7 @@ class SystemDatabase:
         engine_kwargs: Dict[str, Any],
         sys_db_name: Optional[str] = None,
         debug_mode: bool = False,
+        client_mode: bool = False,
     ):
         # Set driver
         system_db_url = sa.make_url(database_url).set(drivername="postgresql+psycopg")
@@ -241,7 +242,7 @@ class SystemDatabase:
             sysdb_name = system_db_url.database + SystemSchema.sysdb_suffix
         system_db_url = system_db_url.set(database=sysdb_name)
 
-        if not debug_mode:
+        if not debug_mode and not client_mode:
             # If the system database does not already exist, create it
             engine = sa.create_engine(
                 system_db_url.set(database="postgres"), **engine_kwargs
@@ -262,7 +263,7 @@ class SystemDatabase:
         )
 
         # Run a schema migration for the system database
-        if not debug_mode:
+        if not debug_mode and not client_mode:
             migration_dir = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)), "_migrations"
             )

--- a/dbos/cli/cli.py
+++ b/dbos/cli/cli.py
@@ -258,6 +258,8 @@ def migrate(
                 "pool_size": 2,
             },
         )
+        sys_db.run_migrations()
+        app_db.run_migrations()
     except Exception as e:
         typer.echo(f"DBOS system schema migration failed: {e}")
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ def sys_db(config: DBOSConfig) -> Generator[SystemDatabase, Any, None]:
             "connect_args": {"connect_timeout": 30},
         },
     )
+    sys_db.run_migrations()
     yield sys_db
     sys_db.destroy()
 
@@ -65,6 +66,7 @@ def app_db(config: DBOSConfig) -> Generator[ApplicationDatabase, Any, None]:
             "connect_args": {"connect_timeout": 30},
         },
     )
+    app_db.run_migrations()
     yield app_db
     app_db.destroy()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -31,6 +31,19 @@ def run_client_collateral() -> None:
     runpy.run_path(filename)
 
 
+def test_client_no_migrate(dbos: DBOS, config: DBOSConfig) -> None:
+    # Drop the system database
+    DBOS.destroy()
+    DBOS(config=config)
+    DBOS.reset_system_database()
+
+    # The client should not be able to connect to the system database
+    with pytest.raises(Exception) as exc_info:
+        client = DBOSClient(config["database_url"])
+        client.list_workflows()
+    assert f'database "dbostestpy_dbos_sys" does not exist' in str(exc_info.value)
+
+
 def test_client_enqueue_and_get_result(dbos: DBOS, client: DBOSClient) -> None:
     run_client_collateral()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,6 +39,7 @@ def test_client_no_migrate(dbos: DBOS, config: DBOSConfig) -> None:
 
     # The client should not be able to connect to the system database
     with pytest.raises(Exception) as exc_info:
+        assert config["database_url"] is not None
         client = DBOSClient(config["database_url"])
         client.list_workflows()
     assert f'database "dbostestpy_dbos_sys" does not exist' in str(exc_info.value)


### PR DESCRIPTION
This PR makes sure that DBOS Client doesn't run migrations on either the system database or the application database. Added a test.